### PR TITLE
Update map.jinja

### DIFF
--- a/awscli/map.jinja
+++ b/awscli/map.jinja
@@ -6,6 +6,6 @@
         'pip_pkg': 'python-pip',
     },
     'FreeBSD': {
-        'pip_pkg': 'py27-pip',
+        'pip_pkg': 'py36-pip',
     },
 }, merge=salt['pillar.get']('awscli:lookup')) %}


### PR DESCRIPTION
Python 3 is now the default version in FreeBSD 11.x